### PR TITLE
fix: new preloads and bootstrappers

### DIFF
--- a/src/bundles/ipfs.js
+++ b/src/bundles/ipfs.js
@@ -152,7 +152,6 @@ function initJsIpfs(Ipfs, opts) {
             '/dns4/sjc-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
             '/dns4/sjc-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp',
             '/dns4/ams-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
-            '/dns4/ams-rust.bootstrap.libp2p.io/tcp/443/wss/p2p/12D3KooWEZXjE41uU4EL2gpkAQeDXYok6wghN7wwNVPF5bwkaNfS',
             '/dns4/ewr-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
             '/dns4/node0.preload.ipfs.io/tcp/443/wss/p2p/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
             '/dns4/node1.preload.ipfs.io/tcp/443/wss/p2p/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6',

--- a/src/bundles/ipfs.js
+++ b/src/bundles/ipfs.js
@@ -144,7 +144,36 @@ function getUserOpts(key) {
 
 function initJsIpfs(Ipfs, opts) {
   return new Promise((resolve, reject) => {
-    const ipfs = new Ipfs(opts)
+    const jsIpfsOpts = Object.assign(
+      {
+        config: {
+          Bootstrap: [
+            '/dns4/nrt-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt',
+            '/dns4/sjc-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+            '/dns4/sjc-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp',
+            '/dns4/ams-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+            '/dns4/ams-rust.bootstrap.libp2p.io/tcp/443/wss/p2p/12D3KooWEZXjE41uU4EL2gpkAQeDXYok6wghN7wwNVPF5bwkaNfS',
+            '/dns4/ewr-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+            '/dns4/node0.preload.ipfs.io/tcp/443/wss/p2p/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
+            '/dns4/node1.preload.ipfs.io/tcp/443/wss/p2p/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6',
+            '/dns4/node2.preload.ipfs.io/tcp/443/wss/p2p/QmV7gnbW5VTcJ3oyM2Xk1rdFBJ3kTkvxc87UFGsun29STS',
+            '/dns4/node3.preload.ipfs.io/tcp/443/wss/p2p/QmY7JB6MQXhxHvq7dBDh4HpbH29v4yE9JRadAVpndvzySN'
+          ]
+        },
+        preload: {
+          enabled: true,
+          addresses: [
+            '/dns4/node0.preload.ipfs.io/tcp/443/https',
+            '/dns4/node1.preload.ipfs.io/tcp/443/https',
+            '/dns4/node2.preload.ipfs.io/tcp/443/https',
+            '/dns4/node3.preload.ipfs.io/tcp/443/https'
+          ]
+        }
+      },
+      opts
+    )
+
+    const ipfs = new Ipfs(jsIpfsOpts)
     ipfs.once('ready', () => resolve(ipfs))
     ipfs.once('error', err => reject(err))
   })


### PR DESCRIPTION
This PR should fix explore.ipld.io (make it function again)

## Explainer

Website uses js-ipfs 0.40.0 (oooold one) and bootstrappers addrs in default config there are invalid.
It also has only 2 preloads instead of 4.

This means only `node0` and `node1` are reachable and used for data transfer over websockets (after preload call makes sure data is on the node), and it is most likely what fails (due to high load) and why website is useless at peak hours.

## Note on bootstrappers 

The website uses old js-ipfs which is unable to resolve `/dnsaddr`, and updating to the latest version is too costly to do it in short amount of time. I've found a way to add 2 additional preloads nodes and manually defined `/dns4`  addrs for additional bootstrappers.

Works as expected:

> ![2021-09-22_12-56](https://user-images.githubusercontent.com/157609/134332784-52eebeff-700b-4c3d-b863-bbee2919b9ff.png)



cc @warpfork @guseggert @gmasgras @olizilla 