### PR TITLE
fix: url-encoded dag-PB paths can be explored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "internal-nav-helper": "^3.1.0",
         "intl-messageformat": "^9.12.0",
         "ipfs-css": "^1.3.0",
-        "ipld-explorer-components": "^4.0.1",
+        "ipld-explorer-components": "^4.0.2",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -7754,9 +7754,9 @@
       }
     },
     "node_modules/ipld-explorer-components": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-explorer-components/-/ipld-explorer-components-4.0.1.tgz",
-      "integrity": "sha512-MjG1OhHoxFE/J0WVi00zo/Nhss3RI/zBRVkWhEnk6mVYjmgzaNsqtwg9MxRgR0JVcHedJvtZbONSZeiz5O4cPg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ipld-explorer-components/-/ipld-explorer-components-4.0.2.tgz",
+      "integrity": "sha512-rocTpQqg0RsevfCdLo6nNyDOk+cEMDg6Pu+yGFSOKRkGvrQuPq8S/cPsx5QJFfuv4sPN01dSvHiZz+/DEndLfg==",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^8.0.0",
         "@chainsafe/libp2p-noise": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "internal-nav-helper": "^3.1.0",
     "intl-messageformat": "^9.12.0",
     "ipfs-css": "^1.3.0",
-    "ipld-explorer-components": "^4.0.1",
+    "ipld-explorer-components": "^4.0.2",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
fixes #122

fix was in ipld-explorer-components: https://github.com/ipfs/ipld-explorer-components/pull/384

demo: https://bafybeiay73jdquwji6ijda2tmq5keh3tntvbpr6o34ycpubbu2wrj6eice.on.fleek.co/#/explore/bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze/1D_exceptions/0CA%252fMonitor_%252f%252f
