### PR TITLE
Improve app's bootstrap HTML metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <title>Explore | IPLD</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
+    <meta name="theme-color" content="#55B8BE">
+    <meta name="description" content="Explore the Merkle Forest from the comfort of your browser">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json">
     <link rel="shortcut icon" href="/favicon.ico">
-    <title>IPFS</title>
+    <link rel="canonical" href="https://explore.ipld.io/">
   </head>
   <body>
     <noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Explore IPLD",
+  "name": "Explore | IPLD",
   "icons": [
     {
       "src": "favicon.ico",
@@ -10,6 +10,6 @@
   ],
   "start_url": "./index.html",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#55B8BE",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
Some simple changes to remove defaults from the CreateReactApp origins:

- Corrects the bootstrap HTML's title to match the one that's loaded from the React app
- Adds a meta description (pulled from the Github repo)
- Adds an IPFS theme colour (in HTML meta, and in `manifest.json`)
- Replaces defaults in `manifest.json`
- Adds canonical link to bootstrap HTML